### PR TITLE
Support terraform workspaces

### DIFF
--- a/src/gulp-execute/index.js
+++ b/src/gulp-execute/index.js
@@ -20,6 +20,7 @@ module.exports = function makeRunner(
     args/*: Array<string> */, opts/*: Object */ = {}
   )/*: Promise<void> */ {
     return new Promise((ok/*: () => void */, fail/*: (Error) => void */) => {
+      const stdout = [];
       const runningProcess = childProcess.spawn(
         executable, args,
         Object.assign({
@@ -35,9 +36,10 @@ module.exports = function makeRunner(
       runningProcess.stdout.on('data', (data/*: Buffer */) => {
         data.toString().replace(/\n$/, '')
         .split('\n')
-        .forEach((line/*: string */) => gutil.log('[%s] %s',
-          gutil.colors.blue.bold(shortName),
-          line));
+        .forEach((line/*: string */) => {
+          gutil.log('[%s] %s', gutil.colors.blue.bold(shortName), line);
+          stdout.push(line);
+        });
       });
       runningProcess.stderr.on('data', (data/*: Buffer */) => {
         data.toString().replace(/\n$/, '')
@@ -53,7 +55,7 @@ module.exports = function makeRunner(
           ));
         } else {
           gutil.log(gutil.colors.green(`${displayName} finished successfully`));
-          ok();
+          ok(stdout);
         }
       });
     });

--- a/src/gulp-terraform/index.js
+++ b/src/gulp-terraform/index.js
@@ -173,6 +173,7 @@ module.exports = {
   'untaint',
   'validate',
   'version',
+  'workspace',
 ].forEach((commandName) => {
   module.exports[commandName] = commandRunner(commandName);
 });

--- a/src/gulp-terraform/test/commands.js
+++ b/src/gulp-terraform/test/commands.js
@@ -21,6 +21,7 @@ describe('command convenience functions', function () {
     'untaint',
     'validate',
     'version',
+    'workspace',
   ].forEach((cmdName) => describe(`terraform.${cmdName}`, function () {
     it(`should run the "${cmdName}" command`, function () {
       expect(tf[cmdName]).to.be.a('function');


### PR DESCRIPTION
This PR adds support for Terraform workspaces in _gulp-terraform_.
To make it more useful for automation purposes, such as getting a the active and available workspaces, a change to make _gulp-execute_ resolve its promise with the stdout of the application being run is also included. 