### PR TITLE
gulp-execute: reject promise w/ error msg from stderr / gulp-execute/gulp-terraform: remove dep on gutil

### DIFF
--- a/src/gulp-execute/package.json
+++ b/src/gulp-execute/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "dependencies": {
     "gulp-util": "^3.0.8",
-    "through2": "^2.0.3"
+    "through2": "^2.0.3",
+    "strip-ansi": "^4.0.0"
   },
   "devDependencies": {
     "gulp": "github:gulpjs/gulp#4.0",

--- a/src/gulp-execute/package.json
+++ b/src/gulp-execute/package.json
@@ -3,14 +3,16 @@
   "version": "0.0.1-develop",
   "main": "index.js",
   "dependencies": {
-    "gulp-util": "^3.0.8",
-    "through2": "^2.0.3",
-    "strip-ansi": "^4.0.0"
+    "ansi-colors": "^2.0.5",
+    "fancy-log": "^1.3.2",
+    "plugin-error": "^1.0.1",
+    "strip-ansi": "^4.0.0",
+    "through2": "^2.0.3"
   },
   "devDependencies": {
-    "gulp": "github:gulpjs/gulp#4.0",
     "eslint": "^3.19.0",
-    "eslint-config-kennship": "0.0.0-develop"
+    "eslint-config-kennship": "0.0.0-develop",
+    "gulp": "github:gulpjs/gulp#4.0"
   },
   "peerDependencies": {
     "gulp": ">=3"

--- a/src/gulp-terraform/package.json
+++ b/src/gulp-terraform/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@kennship/gulp-execute": "*",
     "decamelize": "^1.2.0",
-    "gulp-util": "^3.0.8",
     "lodash": "^4.17.4",
     "through2": "^2.0.3"
   },


### PR DESCRIPTION
In my [last PR](https://github.com/kennship/js-utils/pull/2/commits/cac23d3df0357fb806fa2b23755f90185a1b5714) I made gulp-execute resolve its promise w/ the contents from stdout. This PR expands on this and makes the gulp-execute reject its promise w/ the contents of stderr, so the error can be analyzed programatically. Ansi colors are now stripped from stdout and stderr before they are being recolored for console output. 

I also went ahead and removed the dependency on the deprecated gulp-util in both gulp-execute and gulp-terraform.

